### PR TITLE
Fix for using functions

### DIFF
--- a/desktop+.el
+++ b/desktop+.el
@@ -53,9 +53,10 @@
 
 ;;; Code:
 (eval-when-compile
-  (require 'desktop)
-  (require 'dash)
-  (require 'f))
+  (require 'dash))
+
+(require 'desktop)
+(require 'f)
 
 ;; * Named sessions
 


### PR DESCRIPTION
This package uses a function of `f` and a function `desktop`. So loading those should not be wrapped `eval-when-compile`. I got following byte-compile warnings.

```
In end of data:
desktop+.el:318:1:Warning: the following functions might not be defined at runtime:
    desktop-kill, f-canonical
```