### PR TITLE
Use ido-mode when loading desktops

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ $ emacs-desktop
             indirect-buffer))
     ```
 
+- `desktop+-use-ido`: whether to use ido-mode for completing desktop names. The default is not to use ido (`nil`). To enable it you can use: `(setq desktop+-use-ido t)`.
+
 
 ## API
 

--- a/desktop+.el
+++ b/desktop+.el
@@ -72,6 +72,9 @@ This function must accept the desktop name as a string argument
 and return a frame title format suitable for setting
 `frame-title-format'")
 
+(defvar destop+-use-ido nil
+  "Whether to use ido-mode.")
+
 ;; ** Entry points
 
 ;;;###autoload
@@ -109,10 +112,15 @@ As a special case, if NAME is left blank, the session is
 automatically named after the current working directory."
   (interactive
    (list
-    (completing-read "Desktop name: "
-                     (remove "."
-                             (remove ".."
-                                     (directory-files desktop+-base-dir))))))
+    (if desktop+-use-ido
+        (ido-completing-read "Desktop name: "
+                             (remove "."
+                                     (remove ".."
+                                             (directory-files desktop+-base-dir))))
+      (completing-read "Desktop name: "
+                       (remove "."
+                               (remove ".."
+                                       (directory-files desktop+-base-dir)))))))
   (desktop-change-dir (desktop+--dirname name))
   (desktop+--set-frame-title)
   (desktop-save-mode 1))


### PR DESCRIPTION
Use `ido-completing-read` to select desktops if `desktop+-use-ido` is true.
Resolves #7.