### PR TITLE
add Man-mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
      - terminal buffers (in `term-mode`)
      - org agenda & todo lists (in `org-agenda-mode`)
      - indirect buffers (a.k.a clones).
+     - man pages (in `Man-mode`)
 
 
 
@@ -114,7 +115,8 @@ $ emacs-desktop
           '(term-mode
             compilation-mode
             org-agenda-mode
-            indirect-buffer))
+            indirect-buffer
+            Man-mode))
     ```
 
 

--- a/desktop+.el
+++ b/desktop+.el
@@ -160,7 +160,8 @@ Returns the following frame title format:
   '(term-mode
     compilation-mode
     org-agenda-mode
-    indirect-buffer)
+    indirect-buffer
+    Man-mode)
   "List of special buffers to handle.")
 
 ;; ** Entry point
@@ -295,6 +296,25 @@ from information stored in ARGS, as determined by SAVE-FN."
   (lambda (name &rest args)
     (with-current-buffer (get-buffer (plist-get args :base))
       (clone-indirect-buffer name nil))))
+
+;; *** Man-mode buffers
+
+(defun desktop+--Man-mode-hook ()
+  (setq desktop-save-buffer #'desktop+--Man-save-buffer))
+
+(defun desktop+--Man-save-buffer (dirname)
+  "Return relevant parameters for saving a `Man-mode' buffer."
+  (list :arguments Man-arguments))
+
+(defun desktop+--Man-restore-buffer (file-name buffer-name misc)
+  "Restore a `Man-mode' buffer."
+  (with-current-buffer (man (plist-get misc :arguments))
+    (rename-buffer buffer-name)))
+
+(when (memq 'Man-mode desktop+-special-buffer-handlers)
+  (add-hook 'Man-mode-hook 'desktop+--Man-mode-hook)
+  (add-to-list 'desktop-buffer-mode-handlers
+               '(Man-mode . desktop+--Man-restore-buffer)))
 
 ;; ** Inner workings
 

--- a/features/special.feature
+++ b/features/special.feature
@@ -105,3 +105,25 @@ Feature: Handle special buffers
 
     Given I switch to buffer "*Org Agenda*"
     Then I should see "TODO"
+
+
+  Scenario: Handle man buffer
+    Given I am in a fresh Emacs instance
+    When I call M-x "desktop+-create" RET "man" RET
+    Then Desktop session "man" should exist
+
+    When  I start an action chain
+    And    I press "M-x"
+    And    I type "man"
+    And    I press "RET cat"
+    And    I execute the action chain
+    Given I sleep for "1" second
+    Then Buffer "*Man cat*" should exist
+
+    Given I am in a fresh Emacs instance
+    When I call M-x "desktop+-load" RET "man" RET
+    Given I sleep for "1" second
+    Then Buffer "*Man cat*" should exist
+
+    Given I switch to buffer "*Man cat*"
+    Then I should see "CAT"

--- a/features/step-definitions/desktop+-steps.el
+++ b/features/step-definitions/desktop+-steps.el
@@ -62,3 +62,12 @@
           (cl-assert (string= program command) nil
                      "Expected process `%s' to be running; found `%s' instead"
                      program command))))
+
+(Given "^I sleep for \"\\([0-9]+\\)\" seconds?$"
+       (lambda (seconds callback)
+         (let* ((target (+ (float-time) (string-to-number seconds))))
+           ;; sometimes `sleep-for' returns early...
+           ;; circumvent this by busy-waiting until enough time has passed
+           (while (< (float-time) target)
+             (sleep-for (- target (float-time))))
+           (funcall callback))))


### PR DESCRIPTION
Save and restore buffers in `Man-mode`, the major mode created by
`M-x man`.

`Man-mode` is pretty simple to save and restore; each buffer is
read-only and can be re-generated through the `man` unix command.