### PR TITLE
add shell-mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
      - org agenda & todo lists (in `org-agenda-mode`)
      - indirect buffers (a.k.a clones).
      - man pages (in `Man-mode`)
+     - shell buffers (in `shell-mode`)
 
 
 
@@ -116,7 +117,8 @@ $ emacs-desktop
             compilation-mode
             org-agenda-mode
             indirect-buffer
-            Man-mode))
+            Man-mode
+            shell-mode))
     ```
 
 

--- a/desktop+.el
+++ b/desktop+.el
@@ -161,7 +161,8 @@ Returns the following frame title format:
     compilation-mode
     org-agenda-mode
     indirect-buffer
-    Man-mode)
+    Man-mode
+    shell-mode)
   "List of special buffers to handle.")
 
 ;; ** Entry point
@@ -315,6 +316,32 @@ from information stored in ARGS, as determined by SAVE-FN."
   (add-hook 'Man-mode-hook 'desktop+--Man-mode-hook)
   (add-to-list 'desktop-buffer-mode-handlers
                '(Man-mode . desktop+--Man-restore-buffer)))
+
+;; *** shell-mode
+
+(defun desktop+--shell-mode-hook ()
+  (setq desktop-save-buffer #'desktop+--shell-save-buffer))
+
+(defun desktop+--shell-save-buffer (dirname)
+  "Return relevant parameters for saving a `shell-mode' buffer.
+
+Currently, it saves and restores the current working directory.
+
+The text in the buffer, as well as environment variables, shell
+variables and other state are lost."
+  (list :dir default-directory))
+
+(defun desktop+--shell-restore-buffer (file-name buffer-name misc)
+  "Restore a `shell-mode' buffer."
+  (let* ((dir (plist-get misc :dir))
+         (default-directory (if (file-directory-p dir) dir "/")))
+    (with-current-buffer (shell)
+      (rename-buffer buffer-name))))
+
+(when (memq 'shell-mode desktop+-special-buffer-handlers)
+  (add-hook 'shell-mode-hook 'desktop+--shell-mode-hook)
+  (add-to-list 'desktop-buffer-mode-handlers
+               '(shell-mode . desktop+--shell-restore-buffer)))
 
 ;; ** Inner workings
 

--- a/features/special.feature
+++ b/features/special.feature
@@ -127,3 +127,22 @@ Feature: Handle special buffers
 
     Given I switch to buffer "*Man cat*"
     Then I should see "CAT"
+
+
+  Scenario: Handle shell directory
+    Given I am in a fresh Emacs instance
+    When I call M-x "desktop+-create" RET "shell" RET
+    Then Desktop session "shell" should exist
+
+    When I switch to directory "/tmp"
+    When  I start an action chain
+    And    I press "M-x"
+    And    I type "shell"
+    And    I press "RET"
+    And    I execute the action chain
+
+    Given I am in a fresh Emacs instance
+    When I call M-x "desktop+-load" RET "shell" RET
+    Then Buffer "*shell*" should exist
+    When I switch to buffer "*shell*"
+    Then Variable "default-directory" should be "/tmp/"


### PR DESCRIPTION
Save and restore buffers in `shell-mode`, the major mode created by
`M-x shell`. `shell-mode` is similar to `term-mode`, but runs a
`comint-mode` unix shell instead of a full-blown terminal emulator.

The current directory is preserved between boots. If the current
directory no longer exists, it falls back on `/` to avoid errors.

The contents of the buffer are not preserved. I plan to add this in a
future commit.